### PR TITLE
Enable Nix flakes features in CI

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,6 +15,8 @@ jobs:
       # Install Nix on the GitHub-hosted runner
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v10
+        with:
+          extra-conf: experimental-features = nix-command flakes
 
       # Optional but recommended: speed up builds with their cache
       - name: Magic Nix Cache


### PR DESCRIPTION
## Summary
- configure the Nix installer action to enable nix-command and flakes support via extra-conf

## Testing
- nix run nixpkgs#nixfmt-rfc-style -- -c . *(fails: nix not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d09cdc0e508333bbd244fff1e88225