### PR TITLE
Bind system attr for justnixvim in dev profile

### DIFF
--- a/shared/desktop/dev/default.nix
+++ b/shared/desktop/dev/default.nix
@@ -1,4 +1,7 @@
 { pkgs, inputs, ... }:
+let
+  system = pkgs.stdenv.hostPlatform.system;
+in
 {
   imports = [
     # ./R


### PR DESCRIPTION
## Summary
- bind the host platform system attribute before selecting the justnixvim package in the dev desktop profile

## Testing
- `sudo nixos-rebuild test --flake .#devb0xNixos` *(fails: `nixos-rebuild` not available in container)*
- `journalctl -u home-manager-devbox.service` *(no journal entries in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ac7883f4833388c9cceb1a7619a1