### PR TITLE
Expose pkgs in kitty module

### DIFF
--- a/shared/desktop/kitty.nix
+++ b/shared/desktop/kitty.nix
@@ -1,4 +1,4 @@
-_: {
+{ pkgs, ... }: {
   programs.kitty = {
     enable = true;
     font = {


### PR DESCRIPTION
## Summary
- destructure pkgs in the kitty module lambda so the zsh path can be composed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0b4be9ca083339e251c8d61208089