### PR TITLE
Use attribute import args for desktop scripts

### DIFF
--- a/shared/desktop/bin/default.nix
+++ b/shared/desktop/bin/default.nix
@@ -1,9 +1,9 @@
 { pkgs, ... }:
 let
   # change wallpaper
-  change_wallpaper = import ./change_wallpaper.nix pkgs;
-  select_wallpaper = import ./select_wallpaper.nix pkgs;
-  startup = import ./startup.nix pkgs;
+  change_wallpaper = import ./change_wallpaper.nix { inherit pkgs; };
+  select_wallpaper = import ./select_wallpaper.nix { inherit pkgs; };
+  startup = import ./startup.nix { inherit pkgs; };
 in
 [
   change_wallpaper


### PR DESCRIPTION
## Summary
- update the shared desktop script imports to pass pkgs via an attribute set

## Testing
- not run (nix command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0b45429dc83338ebe6a68c13b52b5