### PR TITLE
Include lib in dev desktop module arguments

### DIFF
--- a/shared/desktop/dev/default.nix
+++ b/shared/desktop/dev/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, inputs, ... }:
+{ pkgs, inputs, lib, ... }:
 let
   system = pkgs.stdenv.hostPlatform.system;
 in


### PR DESCRIPTION
## Summary
- add the `lib` argument to the shared desktop dev module so downstream imports can inherit it

## Testing
- not run (nix command is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0b3b29fb08333a1682674b9dbe0c0