### PR TITLE
Fix lib import in dev desktop module

### DIFF
--- a/shared/desktop/dev/default.nix
+++ b/shared/desktop/dev/default.nix
@@ -88,7 +88,7 @@ in
       vim
       inputs.justnixvim.packages.${system}.default
       (import ./qwen-code.nix {
-        inherit lib;
+        inherit (pkgs) lib;
         buildNpmPackage = pkgs.buildNpmPackage;
         fetchFromGitHub = pkgs.fetchFromGitHub;
         fetchNpmDeps = pkgs.fetchNpmDeps;


### PR DESCRIPTION
## Summary
- reference `lib` from `pkgs` when importing the qwen code module

## Testing
- `nix build .#nixosConfigurations.devb0xNixos.config.system.build.toplevel --dry-run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c43f88f08333931c0adb3bea0051