### PR TITLE
Simplify desktop helper imports

### DIFF
--- a/shared/desktop/bin/default.nix
+++ b/shared/desktop/bin/default.nix
@@ -1,12 +1,6 @@
 { pkgs, ... }:
-let
-  # change wallpaper
-  change_wallpaper = import ./change_wallpaper.nix { inherit pkgs; };
-  select_wallpaper = import ./select_wallpaper.nix { inherit pkgs; };
-  startup = import ./startup.nix { inherit pkgs; };
-in
 [
-  change_wallpaper
-  select_wallpaper
-  startup
+  (import ./change_wallpaper.nix { inherit pkgs; })
+  (import ./select_wallpaper.nix { inherit pkgs; })
+  (import ./startup.nix { inherit pkgs; })
 ]


### PR DESCRIPTION
## Summary
- load the desktop helper scripts by directly importing each nix expression with `inherit pkgs`

## Testing
- nix build .#homeConfigurations.devb0x.activationPackage *(fails: `nix` executable is unavailable in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c4c47a548333ab2c61cec2846b73