### PR TITLE
Fix kitty module zsh shell resolution

### DIFF
--- a/shared/desktop/kitty.nix
+++ b/shared/desktop/kitty.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }: {
+{ pkgs, lib, ... }: {
   programs.kitty = {
     enable = true;
     font = {
@@ -17,7 +17,7 @@
   };
   programs.tmux = {
     enable = true;
-    shell = "\${pkgs.zsh}/bin/zsh";
+    shell = lib.getExe pkgs.zsh;
   };
 
 }


### PR DESCRIPTION
## Summary
- destructure `pkgs` in the kitty home-manager module and use `lib.getExe` for the tmux shell

## Testing
- `nix build .#nixosConfigurations.devb0xNixos.config.system.build.toplevel` *(fails: `nix` command not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c5ba28f48333a433be58c86db89c