### PR TITLE
Use module lib argument in dev profile

### DIFF
--- a/shared/desktop/dev/default.nix
+++ b/shared/desktop/dev/default.nix
@@ -88,7 +88,7 @@ in
       vim
       inputs.justnixvim.packages.${system}.default
       (import ./qwen-code.nix {
-        inherit (pkgs) lib;
+        inherit lib;
         buildNpmPackage = pkgs.buildNpmPackage;
         fetchFromGitHub = pkgs.fetchFromGitHub;
         fetchNpmDeps = pkgs.fetchNpmDeps;


### PR DESCRIPTION
## Summary
- use the lib argument provided to the dev desktop module when importing qwen-code.nix

## Testing
- nix build .#nixosConfigurations.devb0xNixos.config.home-manager.users.devbox.activationPackage *(fails: command not found: nix)*

------
https://chatgpt.com/codex/tasks/task_e_68d0cc580c048333bbf7d17da9d59898