### PR TITLE
Use pkgs when importing desktop helper scripts

### DIFF
--- a/shared/desktop/bin/default.nix
+++ b/shared/desktop/bin/default.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 [
-  (import ./change_wallpaper.nix { inherit pkgs; })
-  (import ./select_wallpaper.nix { inherit pkgs; })
-  (import ./startup.nix { inherit pkgs; })
+  import ./change_wallpaper.nix { inherit pkgs; }
+  import ./select_wallpaper.nix { inherit pkgs; }
+  import ./startup.nix { inherit pkgs; }
 ]


### PR DESCRIPTION
## Summary
- update the desktop helper list to call each helper module via `import` and pass the `pkgs` attribute

## Testing
- not run (nix is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d0cd16b4a08333a49f6dba19cfc0b3