### PR TITLE
Destructure pkgs in kitty module

### DIFF
--- a/shared/desktop/kitty.nix
+++ b/shared/desktop/kitty.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }: {
+{ pkgs, ... }: {
   programs.kitty = {
     enable = true;
     font = {
@@ -17,7 +17,7 @@
   };
   programs.tmux = {
     enable = true;
-    shell = lib.getExe pkgs.zsh;
+    shell = pkgs.lib.getExe pkgs.zsh;
   };
 
 }


### PR DESCRIPTION
## Summary
- destructure pkgs in the kitty Home Manager module
- resolve the tmux shell definition via pkgs.lib.getExe to match the new header

## Testing
- ⚠️ `nix flake check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0cdbd1ea88333860f348ae871b8a4