### PR TITLE
refactor: inherit pkgs utilities in kitty module

### DIFF
--- a/shared/desktop/kitty.nix
+++ b/shared/desktop/kitty.nix
@@ -1,4 +1,7 @@
-{ pkgs, ... }: {
+{ pkgs, ... }:
+let
+  inherit (pkgs) lib zsh;
+in {
   programs.kitty = {
     enable = true;
     font = {
@@ -17,7 +20,7 @@
   };
   programs.tmux = {
     enable = true;
-    shell = pkgs.lib.getExe pkgs.zsh;
+    shell = lib.getExe zsh;
   };
 
 }


### PR DESCRIPTION
## Summary
- destructure `pkgs` in the shared kitty module so `lib` and `zsh` can be inherited directly

## Testing
- `nix build '.#nixosConfigurations.devb0xNixos.config.home-manager.users.devbox.activationPackage'` *(fails: `nix` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d53ca49883339b0c174893bc89ca