### PR TITLE
Fix lib inheritance for qwen dev profile

### DIFF
--- a/shared/desktop/dev/default.nix
+++ b/shared/desktop/dev/default.nix
@@ -88,7 +88,7 @@ in
       vim
       inputs.justnixvim.packages.${system}.default
       (import ./qwen-code.nix {
-        inherit lib;
+        inherit (pkgs) lib;
         buildNpmPackage = pkgs.buildNpmPackage;
         fetchFromGitHub = pkgs.fetchFromGitHub;
         fetchNpmDeps = pkgs.fetchNpmDeps;


### PR DESCRIPTION
## Summary
- ensure the qwen-code import inherits lib from pkgs to avoid missing argument errors during evaluation of the dev desktop module

## Testing
- `nix build .#homeConfigurations.dev.activationPackage` *(fails: `nix` command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d94eb1888333a0c4e614ba520835