### PR TITLE
Refactor desktop helper imports

### DIFF
--- a/shared/desktop/bin/default.nix
+++ b/shared/desktop/bin/default.nix
@@ -1,6 +1,11 @@
 { pkgs, ... }:
+let
+  changeWallpaper = import ./change_wallpaper.nix { inherit pkgs; };
+  selectWallpaper = import ./select_wallpaper.nix { inherit pkgs; };
+  startup = import ./startup.nix { inherit pkgs; };
+in
 [
-  import ./change_wallpaper.nix { inherit pkgs; }
-  import ./select_wallpaper.nix { inherit pkgs; }
-  import ./startup.nix { inherit pkgs; }
+  changeWallpaper
+  selectWallpaper
+  startup
 ]


### PR DESCRIPTION
## Summary
- define local bindings for each desktop helper binary using explicit `import ./<name>.nix { inherit pkgs; }`

## Testing
- not run (nix unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0da278dc083338d6ed5cf4fc9bd34