### PR TITLE
Destructure pkgs in kitty module

### DIFF
--- a/shared/desktop/kitty.nix
+++ b/shared/desktop/kitty.nix
@@ -1,7 +1,9 @@
 { pkgs, ... }:
 let
-  inherit (pkgs) lib zsh;
-in {
+  inherit (pkgs) lib;
+  zsh = pkgs.zsh;
+in
+{
   programs.kitty = {
     enable = true;
     font = {
@@ -22,5 +24,4 @@ in {
     enable = true;
     shell = lib.getExe zsh;
   };
-
 }


### PR DESCRIPTION
## Summary
- destructure the kitty module arguments to expose pkgs
- bind pkgs.zsh explicitly for the tmux shell configuration

## Testing
- not run (nix executable is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d0db264e688333a00ca9d310d93a80