### PR TITLE
Fix lib import for qwen code package

### DIFF
--- a/shared/desktop/dev/default.nix
+++ b/shared/desktop/dev/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, inputs, lib, ... }:
+{ pkgs, inputs, ... }:
 let
   system = pkgs.stdenv.hostPlatform.system;
 in


### PR DESCRIPTION
## Summary
- remove the unused `lib` argument from the dev home configuration
- rely on `pkgs.lib` when importing the qwen-code package definition

## Testing
- `nix build .#homeConfigurations.devbox.activationPackage` *(fails: command not found: nix)*

------
https://chatgpt.com/codex/tasks/task_e_68d0df1fdf988333be7e82b9a10b7372