### PR TITLE
Simplify desktop helper imports

### DIFF
--- a/shared/desktop/bin/default.nix
+++ b/shared/desktop/bin/default.nix
@@ -1,11 +1,6 @@
 { pkgs, ... }:
-let
-  changeWallpaper = import ./change_wallpaper.nix { inherit pkgs; };
-  selectWallpaper = import ./select_wallpaper.nix { inherit pkgs; };
-  startup = import ./startup.nix { inherit pkgs; };
-in
 [
-  changeWallpaper
-  selectWallpaper
-  startup
+  (import ./change_wallpaper.nix { inherit pkgs; })
+  (import ./select_wallpaper.nix { inherit pkgs; })
+  (import ./startup.nix { inherit pkgs; })
 ]


### PR DESCRIPTION
## Summary
- inline the helper imports in shared/desktop/bin/default.nix so they each receive { inherit pkgs; }

## Testing
- nix build .#homeConfigurations.devbox.activationPackage *(fails: command not found: nix)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e015c1b08333804c29726e27e3dc