### PR TITLE
Adjust kitty module to destructure pkgs

### DIFF
--- a/shared/desktop/kitty.nix
+++ b/shared/desktop/kitty.nix
@@ -1,8 +1,4 @@
-{ pkgs, ... }:
-let
-  inherit (pkgs) lib;
-  zsh = pkgs.zsh;
-in
+{ pkgs, lib, ... }:
 {
   programs.kitty = {
     enable = true;
@@ -22,6 +18,6 @@ in
   };
   programs.tmux = {
     enable = true;
-    shell = lib.getExe zsh;
+    shell = lib.getExe pkgs.zsh;
   };
 }


### PR DESCRIPTION
## Summary
- destructured `pkgs` directly in the kitty module header
- simplify tmux shell configuration to use `pkgs.zsh` without an intermediate binding

## Testing
- `nix build .#homeConfigurations.devbox.activationPackage` *(fails: `nix` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e0d0fac883338a0640aeb6ea35a0